### PR TITLE
Review Display Fixes/Improvements

### DIFF
--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewDashboardPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewDashboardPage.razor
@@ -315,7 +315,7 @@
         {
             ReviewStatus.Pending => "Start Review",
             ReviewStatus.InProgress => "Resume Review",
-            ReviewStatus.Submitted => "View Review",
+            ReviewStatus.Submitted => "View Reviews",
             ReviewStatus.Declined => "Declined",
             _ => "Review"
         };

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewDashboardPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewDashboardPage.razor
@@ -111,10 +111,17 @@
                     @paper.ReviewSubmittedAtUtc?.LocalDateTime.ToString("M/d/yy h:mm tt")
                 </td>
                 <td>
-                    <button class="btn btn-sm w-100 @(paper.CanSubmitReview ? "btn-primary" : "btn-outline-secondary")"
-                            @onclick="() => OpenReview(paper.PaperId)">
-                        @GetReviewButtonText(paper)
-                    </button>
+                    @if (ShouldShowReviewButton(paper))
+                    {
+                        <button class="btn btn-sm w-100 @GetReviewButtonClass(paper)"
+                                @onclick="() => OpenReview(paper.PaperId)">
+                            @GetReviewButtonText(paper)
+                        </button>
+                    }
+                    else
+                    {
+                        <span class="text-muted">—</span>
+                    }
                 </td>
             </tr>
         }
@@ -164,9 +171,14 @@
     private bool _showAuthors; // double-blind default
     
     private bool _isAdminView;
+    
+    private bool IsAssignedReviewer(ReviewerPaperDTO paper) =>
+        _currentUserId == paper.ReviewerId;
 
     private string PageTitleText =>
         _showAuthors ? "Review Assignments" : "My Review Assignments";
+    
+    private Guid? _currentUserId;
     
     private bool _isLoading = true;
     private List<ReviewerPaperDTO> _papers = [];
@@ -258,6 +270,8 @@
             if (!string.IsNullOrWhiteSpace(userIdClaim))
             {
                 var userId = Guid.Parse(userIdClaim);
+                
+                _currentUserId = userId;
 
                 // Get the user's roles
                 var roles = user.Claims
@@ -286,30 +300,47 @@
         _isLoading = false;
     }
     
-    private static string GetReviewButtonText(ReviewerPaperDTO paper)
+    private string GetReviewButtonText(ReviewerPaperDTO paper)
     {
-        // Chair/Admin (not reviewer)
-        if (paper.ReviewStatus == ReviewStatus.Submitted)
+        var isAssignedReviewer = IsAssignedReviewer(paper);
+
+        // Admin looking at someone else's assignment
+        if (_isAdminView && !isAssignedReviewer)
         {
-            return "View Reviews";
+            return "View Review";
         }
 
-        // Reviewer cases
-        if (paper.CanSubmitReview)
+        // Reviewer or admin reviewing own assignment
+        return paper.ReviewStatus switch
         {
-            return paper.ReviewStatus switch
-            {
-                ReviewStatus.Pending => "Start Review",
-                ReviewStatus.InProgress => "Resume Review",
-                ReviewStatus.Submitted => "View Reviews",
-                ReviewStatus.Declined => "Declined",
-                _ => "Review"
-            };
-        }
+            ReviewStatus.Pending => "Start Review",
+            ReviewStatus.InProgress => "Resume Review",
+            ReviewStatus.Submitted => "View Review",
+            ReviewStatus.Declined => "Declined",
+            _ => "Review"
+        };
+    }
+    
+    private string GetReviewButtonClass(ReviewerPaperDTO paper)
+    {
+        var isAssignedReviewer = IsAssignedReviewer(paper);
 
-        return paper.ReviewSubmittedAtUtc != null
-            ? "View Reviews"
-            : "View";
+        if (_isAdminView && !isAssignedReviewer)
+            return "btn-outline-secondary";
+
+        return paper.CanSubmitReview
+            ? "btn-primary"
+            : "btn-outline-secondary";
+    }
+    
+    private bool ShouldShowReviewButton(ReviewerPaperDTO paper)
+    {
+        var isAssignedReviewer = IsAssignedReviewer(paper);
+
+        // Admin viewing someone else's unfinished assignment
+        return !_isAdminView ||
+               isAssignedReviewer ||
+               paper.ReviewSubmittedAtUtc is not null;
     }
 
     private void SortBy(string column)

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewDashboardPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewDashboardPage.razor
@@ -71,6 +71,14 @@
                     class="@(_showAuthors ? "" : "d-none")">
                     Authors @SortIcon(nameof(ReviewerPaperDTO.Authors))
                 </th>
+                
+                @if (_isAdminView)
+                {
+                    <th role="button"
+                        @onclick="() => SortBy(nameof(ReviewerPaperDTO.ReviewerDisplayName))">
+                        Reviewer @SortIcon(nameof(ReviewerPaperDTO.ReviewerDisplayName))
+                    </th>
+                }
 
                 <th role="button" @onclick="() => SortBy(nameof(ReviewerPaperDTO.ReviewStatus))">
                     Review Status @SortIcon(nameof(ReviewerPaperDTO.ReviewStatus))
@@ -90,6 +98,10 @@
             <tr>
                 <td>@paper.Title</td>
                 <td class="@(_showAuthors ? "" : "d-none")">@paper.Authors</td>
+                @if (_isAdminView)
+                {
+                    <td>@paper.ReviewerDisplayName</td>
+                }
                 <td>
                     <span class="badge @GetStatusBadge(paper.ReviewStatus)">
                         @FormatReviewStatus(paper.ReviewStatus)
@@ -150,6 +162,8 @@
 @code {
     // Determines whether author names should be displayed
     private bool _showAuthors; // double-blind default
+    
+    private bool _isAdminView;
 
     private string PageTitleText =>
         _showAuthors ? "Review Assignments" : "My Review Assignments";
@@ -254,8 +268,12 @@
                 // Admins, PaperChair, or ConferenceChair see all review assignments
                 if (roles.Contains("Admin") || roles.Contains("PaperChair") || roles.Contains("ConferenceChair"))
                 {
-                    _papers = (await ReviewAssignmentService.GetAllReviewerAssignmentsAsync()).ToList();
+                    _isAdminView = true;
                     _showAuthors = true;
+
+                    _papers = (await ReviewAssignmentService
+                            .GetAllReviewerAssignmentsAsync())
+                        .ToList();
                 }
                 else
                 {

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
@@ -15,10 +15,20 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="mb-0">Paper Details</h1>
 
-        <button class="btn btn-outline-secondary"
-                @onclick="GoBack">
-            ← Back to Submissions
-        </button>
+        <div class="d-flex gap-2">
+
+            <button class="btn btn-primary"
+                    @onclick="GoToReviews">
+                <i class="bi bi-clipboard-check"></i>
+                View Reviews
+            </button>
+
+            <button class="btn btn-outline-secondary"
+                    @onclick="GoBack">
+                ← Back to Submissions
+            </button>
+
+        </div>
     </div>
 
     @if (_isLoading)
@@ -176,6 +186,11 @@ else
         }
 
         _isLoading = false;
+    }
+    
+    private void GoToReviews()
+    {
+        NavManager.NavigateTo($"/papers/{PaperId}/review");
     }
     
     private void GoBack()

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionsPage.razor
@@ -96,7 +96,11 @@
                             <td>@paper.Authors</td>
                         }
 
-                        <td>@paper.Status</td>
+                        <td>
+                            <span class="badge @GetPaperStatusBadge(paper.Status)">
+                                @FormatPaperStatus(paper.Status)
+                            </span>
+                        </td>
 
                         <td>
                             @paper.SubmittedAtUtc?.LocalDateTime.ToString("M/d/yy h:mm tt")
@@ -206,6 +210,32 @@
     
     private string? _statusMessage;
     private string _statusMessageType = "info"; // bootstrap: success, danger, warning, info
+    
+    private static string FormatPaperStatus(string status) =>
+        status switch
+        {
+            "Submitted" => "Submitted",
+            "UnderReview" => "Under Review",
+            "ReviewsCompleted" => "Reviews Completed",
+            "RevisionRequired" => "Revision Required",
+            "Accepted" => "Accepted",
+            "Rejected" => "Rejected",
+            "Withdrawn" => "Withdrawn",
+            _ => status
+        };
+    
+    private static string GetPaperStatusBadge(string status) =>
+        status switch
+        {
+            "Submitted" => "bg-secondary",
+            "UnderReview" => "bg-primary",
+            "ReviewsCompleted" => "bg-info text-dark",
+            "RevisionRequired" => "bg-warning text-dark",
+            "Accepted" => "bg-success",
+            "Rejected" => "bg-danger",
+            "Withdrawn" => "bg-dark",
+            _ => "bg-light text-dark"
+        };
     
     // Modal State Variables
     private bool _showDecisionModal;
@@ -387,7 +417,7 @@
             case AcceptAction:
                 if (result.AcceptWithConditions)
                 {
-                    // revisions path
+                    // revision path
                     await ExecuteDecision(
                         _selectedPaperId,
                         (p, u) => PaperDecisionService.RequestRevisionsAsync(p, u, result.Comment),

--- a/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
@@ -45,6 +45,7 @@ namespace Reviewer2.Services.DTOs.ReviewAssignments
 
                         return string.IsNullOrEmpty(role) ? name : $"{name} ({role})";
                     })),
+                ReviewerId = assignment.ReviewerId,
                 ReviewerDisplayName = assignment.Reviewer.FullName,
                 Files = paper.Files.Select(f => new PaperFileSummaryDTO
                 {

--- a/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
@@ -18,10 +18,9 @@ namespace Reviewer2.Services.DTOs.ReviewAssignments
         /// <param name="assignment">The review assignment to map.</param>
         /// <returns>A fully populated <see cref="ReviewerPaperDTO"/>.</returns>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="assignment"/> or its <see cref="ReviewAssignment.Paper"/> is null.</exception>
-        public static ReviewerPaperDTO ToReviewerPaperDto(this ReviewAssignment assignment)
+        public static ReviewerPaperDTO ToReviewerPaperDTO(this ReviewAssignment assignment)
         {
-            if (assignment == null)
-                throw new ArgumentNullException(nameof(assignment));
+            ArgumentNullException.ThrowIfNull(assignment);
             if (assignment.Paper == null)
                 throw new ArgumentNullException(nameof(assignment.Paper));
 
@@ -46,6 +45,7 @@ namespace Reviewer2.Services.DTOs.ReviewAssignments
 
                         return string.IsNullOrEmpty(role) ? name : $"{name} ({role})";
                     })),
+                ReviewerDisplayName = assignment.Reviewer.FullName,
                 Files = paper.Files.Select(f => new PaperFileSummaryDTO
                 {
                     FileId = f.Id,

--- a/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewerPaperDTO.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewerPaperDTO.cs
@@ -50,6 +50,18 @@ public class ReviewerPaperDTO
     /// author order in the submission. They will not always be displayed
     /// </summary>
     public string Authors { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Display name of the reviewer assigned to this paper.
+    ///
+    /// This is primarily populated for Admin, PaperChair,
+    /// and ConferenceChair dashboards where all review
+    /// assignments are visible.
+    ///
+    /// For regular reviewers this may be empty or contain
+    /// the current user's display name.
+    /// </summary>
+    public string ReviewerDisplayName { get; set; } = string.Empty;
 
     /// <summary>
     /// Collection of files associated with the paper, such as
@@ -57,7 +69,7 @@ public class ReviewerPaperDTO
     /// 
     /// Each file includes metadata and a URL for retrieval.
     /// </summary>
-    public List<PaperFileSummaryDTO> Files { get; set; } = new();
+    public List<PaperFileSummaryDTO> Files { get; set; } = [];
     
     /// <summary>
     /// Gets the URL of the initial submission manuscript file associated with this paper, if available.

--- a/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewerPaperDTO.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewerPaperDTO.cs
@@ -52,6 +52,11 @@ public class ReviewerPaperDTO
     public string Authors { get; set; } = string.Empty;
     
     /// <summary>
+    /// The ID used to identify the reviewer associated with this review assignment.
+    /// </summary>
+    public Guid ReviewerId { get; set; }
+    
+    /// <summary>
     /// Display name of the reviewer assigned to this paper.
     ///
     /// This is primarily populated for Admin, PaperChair,

--- a/Reviewer2/Reviewer2.Services/ReviewAssignments/ReviewAssignmentService.cs
+++ b/Reviewer2/Reviewer2.Services/ReviewAssignments/ReviewAssignmentService.cs
@@ -360,6 +360,7 @@ public class ReviewAssignmentService : IReviewAssignmentService
         var assignments = await dbContext.ReviewAssignments
             .Where(ra => ra.ReviewerId == reviewerId)
             .Include(ra => ra.Review)
+            .Include(ra => ra.Reviewer)
             .Include(ra => ra.Paper)
             .ThenInclude(p => p.Authors)
             .ThenInclude(a => a.User)
@@ -371,7 +372,7 @@ public class ReviewAssignmentService : IReviewAssignmentService
 
         // Map assignments to DTOs using the extension method
         var dtos = assignments
-            .Select(ra => ra.ToReviewerPaperDto())
+            .Select(ra => ra.ToReviewerPaperDTO())
             .ToList();
 
         Log.Information("Mapped {Count} review assignments to ReviewerPaperDTO for reviewer {ReviewerId}", dtos.Count, reviewerId);
@@ -388,6 +389,7 @@ public class ReviewAssignmentService : IReviewAssignmentService
 
         // Eagerly load related data for mapping
         var assignments = await dbContext.ReviewAssignments
+            .Include(ra => ra.Reviewer)
             .Include(ra => ra.Review)
             .Include(ra => ra.Paper)
             .ThenInclude(p => p.Authors)
@@ -400,7 +402,7 @@ public class ReviewAssignmentService : IReviewAssignmentService
 
         // Map assignments to DTOs using the extension method
         var dtos = assignments
-            .Select(ra => ra.ToReviewerPaperDto())
+            .Select(ra => ra.ToReviewerPaperDTO())
             .ToList();
 
         Log.Information("Mapped {Count} review assignments to ReviewerPaperDTO", dtos.Count);


### PR DESCRIPTION
## Changes/Improvements
* Reviewer names are now displayed for admins/paper chairs on the review dashboard
* With a new navigation button, users can now go directly to reviews for a given paper (or a review form, depending on the scenario) from that paper's submission details page
* On the paper submissions page, the status column now looks more pretty with colored badges

## Fixes
The action button on the review dashboard for each assignment (table row) now displays the correct option for admins and paper chairs. This includes not displaying any button when there isn't anything worthwhile to navigate to.