### PR TITLE
Paper Revisions and Additional Paper File Uploads

### DIFF
--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
@@ -146,7 +146,10 @@ else
                             <a href="@file.FileUrl"
                                target="_blank"
                                class="btn btn-sm btn-outline-primary">
+
+                                <i class="bi bi-eye me-1"></i>
                                 View
+
                             </a>
                         }
                     </li>
@@ -183,10 +186,12 @@ else
 
                                     @if (_isUploadingRevision)
                                     {
-                                        <span class="spinner-border spinner-border-sm"></span>
+                                        <span class="spinner-border spinner-border-sm me-2"></span>
+                                        <span>Uploading...</span>
                                     }
                                     else
                                     {
+                                        <i class="bi bi-upload me-1"></i>
                                         <span>Upload</span>
                                     }
 

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
@@ -131,7 +131,14 @@ else
                     <li class="list-group-item d-flex justify-content-between align-items-center">
                         <div>
                             <strong>@file.FileType</strong>
-                            <div class="text-muted small">@file.FileName</div>
+
+                            <div class="text-muted small">
+                                @file.FileName
+                            </div>
+
+                            <div class="text-muted small">
+                                Uploaded @file.UploadedAtUtc.ToLocalTime().ToString("g")
+                            </div>
                         </div>
 
                         @if (!string.IsNullOrWhiteSpace(file.FileUrl))

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
@@ -2,9 +2,11 @@
 @rendermode InteractiveServer
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Authorization
+@using Reviewer2.Data.Models
 @using Reviewer2.Services.DTOs.PaperSubmission
 @using Reviewer2.Services.Submissions.PaperSubmission
 @inject IPaperQueryService PaperQueryService
+@inject IPaperSubmissionService PaperService
 @inject AuthenticationStateProvider AuthProvider
 @inject NavigationManager NavManager
 
@@ -142,6 +144,66 @@ else
                         }
                     </li>
                 }
+                @if (IsSubmitter)
+                {
+                    <li class="list-group-item">
+
+                        <div class="row g-2 align-items-center">
+
+                            <div class="col-md-4">
+                                <InputSelect class="form-select"
+                                             @bind-Value="_selectedUploadType">
+
+                                    @foreach (var type in _uploadableTypes)
+                                    {
+                                        <option value="@type">
+                                            @FormatFileType(type)
+                                        </option>
+                                    }
+
+                                </InputSelect>
+                            </div>
+
+                            <div class="col-md-5">
+                                <InputFile OnChange="@HandleFileSelection"
+                                           accept=".pdf,application/pdf" />
+                            </div>
+
+                            <div class="col-md-3">
+                                <button class="btn btn-primary w-100"
+                                        disabled="@(_selectedUploadFile == null || _isUploadingRevision)"
+                                        @onclick="UploadFile">
+
+                                    @if (_isUploadingRevision)
+                                    {
+                                        <span class="spinner-border spinner-border-sm"></span>
+                                    }
+                                    else
+                                    {
+                                        <span>Upload</span>
+                                    }
+
+                                </button>
+                            </div>
+
+                        </div>
+
+                        @if (_selectedUploadFile != null)
+                        {
+                            <div class="text-muted small mt-2">
+                                @_selectedUploadFile.Name
+                            </div>
+                        }
+
+                        @if (!string.IsNullOrWhiteSpace(_uploadError))
+                        {
+                            <div class="alert alert-danger mt-2 mb-0">
+                                @_uploadError
+                            </div>
+                        }
+
+                    </li>
+                }
             </ul>
         </section>
 
@@ -164,6 +226,35 @@ else
 
     private PaperDetailsDTO? _paper;
     private bool _isLoading = true;
+    
+    private Guid? _currentUserId;
+
+    private bool IsSubmitter =>
+        _paper != null &&
+        _currentUserId.HasValue &&
+        _paper.SubmitterUserId == _currentUserId;
+
+    private IBrowserFile? _selectedUploadFile;
+
+    private FileType _selectedUploadType = FileType.Revision;
+
+    private readonly List<FileType> _uploadableTypes =
+    [
+        FileType.Revision,
+        FileType.CameraReady,
+        FileType.CopyrightForm
+    ];
+    
+    private static string FormatFileType(FileType type) =>
+        type switch
+        {
+            FileType.CameraReady => "Camera Ready",
+            FileType.CopyrightForm => "Copyright Form",
+            _ => type.ToString()
+        };
+    
+    private string? _uploadError;
+    private bool _isUploadingRevision;
 
     protected override async Task OnInitializedAsync()
     {
@@ -181,8 +272,8 @@ else
 
         if (!string.IsNullOrWhiteSpace(userIdClaim))
         {
-            var userId = Guid.Parse(userIdClaim);
-            _paper = await PaperQueryService.GetPaperDetailsAsync(PaperId, userId);
+            _currentUserId = Guid.Parse(userIdClaim);
+            _paper = await PaperQueryService.GetPaperDetailsAsync(PaperId, _currentUserId.Value);
         }
 
         _isLoading = false;
@@ -196,5 +287,66 @@ else
     private void GoBack()
     {
         NavManager.NavigateTo("/submissions");
+    }
+    
+    private Task HandleFileSelection(InputFileChangeEventArgs e)
+    {
+        _uploadError = null;
+
+        var file = e.File;
+
+        if (file.ContentType != "application/pdf" ||
+            !file.Name.EndsWith(".pdf",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            _uploadError = "Only PDF files are allowed.";
+            return Task.CompletedTask;
+        }
+
+        _selectedUploadFile = file;
+
+        return Task.CompletedTask;
+    }
+    
+    private async Task UploadFile()
+    {
+        if (!IsSubmitter ||
+            _selectedUploadFile == null ||
+            !_currentUserId.HasValue)
+            return;
+
+        _isUploadingRevision = true;
+        _uploadError = null;
+
+        try
+        {
+            await using var fileStream =
+                _selectedUploadFile.OpenReadStream(500 * 1024 * 1024);
+
+            await using var memoryStream = new MemoryStream();
+
+            await fileStream.CopyToAsync(memoryStream);
+
+            memoryStream.Position = 0;
+
+            await PaperService.UploadFileAsync(
+                PaperId,
+                _selectedUploadType,
+                memoryStream,
+                _selectedUploadFile.Name,
+                _currentUserId.Value);
+
+            _selectedUploadFile = null;
+
+            await LoadPaper();
+        }
+        catch (Exception ex)
+        {
+            _uploadError = ex.Message;
+        }
+        finally
+        {
+            _isUploadingRevision = false;
+        }
     }
 }

--- a/Reviewer2/Reviewer2.Blazor/wwwroot/app.css
+++ b/Reviewer2/Reviewer2.Blazor/wwwroot/app.css
@@ -55,6 +55,64 @@ a:hover,
             );
 }
 
+.btn-outline-primary {
+    color: rgb(40, 110, 200);
+
+    background:
+            linear-gradient(
+                    to bottom,
+                    rgba(255,255,255,0.85),
+                    rgba(220,235,255,0.75)
+            );
+
+    border: 1px solid rgba(40, 110, 200, 0.55);
+
+    box-shadow:
+            inset 0 1px 0 rgba(255,255,255,0.8),
+            0 2px 6px rgba(0,0,0,0.18);
+
+    text-shadow:
+            0 1px 0 rgba(255,255,255,0.65);
+}
+
+
+.btn-outline-primary:hover {
+    color: #fff;
+
+    background:
+            linear-gradient(
+                    to bottom,
+                    rgba(90, 160, 230, 0.95),
+                    rgba(40, 110, 200, 0.95)
+            );
+
+    border: 1px solid rgba(255,255,255,0.4);
+
+    box-shadow:
+            inset 0 1px 0 rgba(255,255,255,0.65),
+            0 2px 6px rgba(0,0,0,0.35);
+}
+
+
+.btn-outline-primary:active {
+    background:
+            linear-gradient(
+                    to bottom,
+                    rgba(40, 110, 200, 0.95),
+                    rgba(90, 160, 230, 0.95)
+            );
+
+    box-shadow:
+            inset 0 2px 4px rgba(0,0,0,0.2);
+}
+
+
+.btn-outline-primary:focus {
+    box-shadow:
+            inset 0 1px 0 rgba(255,255,255,0.8),
+            0 0 0 0.2rem rgba(90, 160, 230, 0.35);
+}
+
 /* Secondary Button */
 .btn-secondary {
     color: #fff;

--- a/Reviewer2/Reviewer2.Data/Models/PaperFile.cs
+++ b/Reviewer2/Reviewer2.Data/Models/PaperFile.cs
@@ -131,14 +131,21 @@ public enum FileType
     InitialSubmission = 0,
 
     /// <summary>
-    /// The final camera-ready version submitted after acceptance.
-    /// This version is typically used for proceedings publication.
+    /// A revised version of the initial paper submission, typically created
+    /// following reviewer feedback.
+    /// This file replaces the initial submission in the review workflow.
     /// </summary>
-    CameraReady = 1,
+    Revision = 1, 
+    
+    /// <summary>
+    /// The final camera-ready version submitted after acceptance.
+    /// This version is typically used for proceeding publication.
+    /// </summary>
+    CameraReady = 2,
 
     /// <summary>
     /// The signed copyright or licensing agreement required
     /// prior to publication.
     /// </summary>
-    CopyrightForm = 2
+    CopyrightForm = 3
 }

--- a/Reviewer2/Reviewer2.Services/DTOs/PaperSubmission/PaperDetailsDTO.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/PaperSubmission/PaperDetailsDTO.cs
@@ -41,6 +41,11 @@ namespace Reviewer2.Services.DTOs.PaperSubmission
         /// Null if no decision has been recorded.
         /// </summary>
         public DateTimeOffset? DecisionMadeAtUtc { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the unique identifier of the user who submitted the paper. Used for identification and authorization.
+        /// </summary>
+        public Guid SubmitterUserId { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the user who submitted the paper.

--- a/Reviewer2/Reviewer2.Services/DTOs/PaperSubmission/PaperFileSummaryDTO.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/PaperSubmission/PaperFileSummaryDTO.cs
@@ -29,5 +29,10 @@ namespace Reviewer2.Services.DTOs.PaperSubmission
         /// This URL may be generated dynamically by the service when returning the DTO.
         /// </summary>
         public string? FileUrl { get; set; }
+        
+        /// <summary>
+        /// The time at which the file was uploaded.
+        /// </summary>
+        public DateTimeOffset UploadedAtUtc { get; set; }
     }
 }

--- a/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
@@ -52,7 +52,8 @@ namespace Reviewer2.Services.DTOs.ReviewAssignments
                     FileId = f.Id,
                     FileName = f.OriginalFileName,
                     FileType = f.Type.ToString(),
-                    FileUrl = $"/api/papers/{paper.Id}/files/{f.Type}"
+                    FileUrl = $"/api/papers/{paper.Id}/files/{f.Type}",
+                    UploadedAtUtc = f.UploadedAtUtc
                 }).ToList(),
 
                 ReviewAssignmentId = assignment.Id,

--- a/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperQueryService.cs
+++ b/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperQueryService.cs
@@ -150,6 +150,7 @@ public class PaperQueryService : IPaperQueryService
             Status = paper.Status.ToString(),
             SubmittedAtUtc = paper.SubmittedAtUtc,
             DecisionMadeAtUtc = paper.LastDecisionAtUtc,
+            SubmitterUserId = paper.SubmitterUserId,
             SubmitterName = $"{paper.Submitter.FirstName} {paper.Submitter.LastName}",
             Authors = paper.Authors
                 .OrderBy(a => a.AuthorOrder)

--- a/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperQueryService.cs
+++ b/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperQueryService.cs
@@ -91,7 +91,8 @@ public class PaperQueryService : IPaperQueryService
                 FileId = f.Id,
                 FileName = f.OriginalFileName,
                 FileType = f.Type.ToString(),
-                FileUrl = null // Can be populated later with a service-generated URL
+                FileUrl = null, // Can be populated later with a service-generated URL
+                UploadedAtUtc = f.UploadedAtUtc
             }).ToList()
         }).ToList();
 
@@ -170,7 +171,8 @@ public class PaperQueryService : IPaperQueryService
                         FileId = f.Id,
                         FileName = f.OriginalFileName,
                         FileType = f.Type.ToString(),
-                        FileUrl = fileUrl
+                        FileUrl = fileUrl,
+                        UploadedAtUtc = f.UploadedAtUtc
                     };
                 })
                 .ToList()
@@ -319,7 +321,8 @@ public class PaperQueryService : IPaperQueryService
                 FileId = f.Id,
                 FileName = f.OriginalFileName,
                 FileType = f.Type.ToString(),
-                FileUrl = $"/api/papers/{p.Id}/files/{f.Type}" // simple API route for now
+                FileUrl = $"/api/papers/{p.Id}/files/{f.Type}", // simple API route
+                UploadedAtUtc = f.UploadedAtUtc
             }).ToList()
         }).ToList();
 


### PR DESCRIPTION
## New Features
This pull request adds...
* A new back-end field for paper files that allows a newly uploaded file to be classified as a revision.
* Revisions, camera ready copies, and copyright forms can all be submitted via the submission details page for a given paper. Only the user who originally submitted the paper can do these uploads.
* When looking at the submission details for a paper, the submission history is now visible with timestamps.