### PR TITLE
Home Page Loading and Logout Fixes

### DIFF
--- a/Reviewer2/Reviewer2.Blazor/Components/Layout/NavMenu.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Layout/NavMenu.razor
@@ -76,7 +76,7 @@
                 <div class="nav-item px-3">
                     <form action="Account/Logout" method="post">
                         <AntiforgeryToken />
-                        <input type="hidden" name="ReturnUrl" value="@currentUrl" />
+                        <input type="hidden" name="ReturnUrl" value="" />
                         <button type="submit" class="nav-link">
                             <div class="align-middle">
                                 <i class="bi bi-box-arrow-right"></i>

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/Home.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/Home.razor
@@ -62,9 +62,43 @@
     else if (_showLoading)
     {
         <div class="placeholder-glow">
-            <span class="placeholder col-6"></span>
-            <span class="placeholder col-8"></span>
-            <span class="placeholder col-4"></span>
+
+            <!-- Conference header -->
+            <div class="mb-4 d-flex justify-content-between align-items-start">
+
+                <div class="flex-grow-1">
+                    <span class="placeholder col-5 mb-2"></span>
+                    <span class="placeholder col-8"></span>
+                </div>
+
+            </div>
+
+            <!-- Call for Papers -->
+            <div class="mb-4">
+                <span class="placeholder col-3 mb-3"></span>
+
+                <div class="d-flex flex-column gap-2">
+                    <span class="placeholder col-12"></span>
+                    <span class="placeholder col-10"></span>
+                    <span class="placeholder col-9"></span>
+                </div>
+            </div>
+
+            <!-- Deadlines -->
+            <div class="mb-4">
+                <span class="placeholder col-2 mb-3"></span>
+
+                <ul class="list-group">
+                    @for (var i = 0; i < 3; i++)
+                    {
+                        <li class="list-group-item d-flex justify-content-between">
+                            <span class="placeholder col-4"></span>
+                            <span class="placeholder col-2"></span>
+                        </li>
+                    }
+                </ul>
+            </div>
+
         </div>
     }
     

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/Home.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/Home.razor
@@ -7,33 +7,15 @@
 <PageTitle>Reviewer2</PageTitle>
 
 <div class="container my-4">
-    @if (_isLoading)
-    {
-        <div class="alert alert-info">Loading conference data...</div>
-    }
-    else if (!string.IsNullOrEmpty(_errorMessage))
+    @if (!string.IsNullOrEmpty(_errorMessage))
     {
         <div class="alert alert-danger">@_errorMessage</div>
     }
-    else if (_conference == null)
-    {
-        <div class="alert alert-warning">
-            No conference has been configured yet.
-        </div>
-
-        <AuthorizeView Roles="Admin, ConferenceChair">
-            <Authorized>
-                <NavLink class="btn btn-primary" href="/conference-edit">
-                    Create Conference
-                </NavLink>
-            </Authorized>
-        </AuthorizeView>
-    }
-    else
+    else if (_conference is not null)
     {
         <!-- Conference Info -->
         <div class="mb-4 d-flex justify-content-between align-items-start">
-    
+
             <div>
                 <h1 class="mb-1">@_conference.Name</h1>
                 <p class="mb-0">@_conference.Description</p>
@@ -77,22 +59,41 @@
             }
         </div>
     }
-    <!-- Volunteer Reviewer Button -->
+    else if (_showLoading)
+    {
+        <div class="placeholder-glow">
+            <span class="placeholder col-6"></span>
+            <span class="placeholder col-8"></span>
+            <span class="placeholder col-4"></span>
+        </div>
+    }
+    
     <div class="mt-4">
         <VolunteerReviewerButton ShowTitle="true" ShowDescription="true" />
     </div>
+    
 </div>
 
 @code {
     private ConferenceDTO? _conference;
-    private bool _isLoading = true;
+    private bool _showLoading;
     private string? _errorMessage;
 
     protected override async Task OnInitializedAsync()
     {
+        var loadingTask = Task.Delay(150);
+
         try
         {
-            _conference = await ConferenceService.GetConferenceAsync();
+            var conferenceTask = ConferenceService.GetConferenceAsync();
+
+            if (await Task.WhenAny(conferenceTask, loadingTask) == loadingTask)
+            {
+                _showLoading = true;
+                StateHasChanged();
+            }
+
+            _conference = await conferenceTask;
         }
         catch
         {
@@ -100,7 +101,7 @@
         }
         finally
         {
-            _isLoading = false;
+            _showLoading = false;
         }
     }
 }


### PR DESCRIPTION
## Fixes
* The home page no longer provides any ability to create a conference. This is not necessary because a default conference is seeded on startup if there is not one. This improves the user experience of loading a Reviewer2 homepage as latency was causing the create a conference option (and some other bootstrap alerts) to display very briefly upon page load. Placeholder text is now rendered in the place of this old content during page loading.
* Logging out will now always redirect a user to the home page. This redirection prevents users from seeing unauthorized messages/errors when logging out from a page that requires special privileges (such as the admin panel).