### PR TITLE
Paper Status Fixes and Additional Review Display Improvements

### DIFF
--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewList.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewList.razor
@@ -10,12 +10,13 @@
 else
 {
     <div class="d-flex flex-column gap-3">
-        @for (int i = 0; i < Reviews.Count; i++)
+        @for (var i = 0; i < Reviews.Count; i++)
         {
             <ReviewViewer
                 Review="Reviews[i]"
                 Index="@(i + 1)"
-                Template="Template" />
+                Template="Template"
+                CurrentUserReviewAssignmentId="CurrentUserReviewAssignmentId"/>
         }
     </div>
 }
@@ -26,4 +27,14 @@ else
     
     [Parameter, EditorRequired]
     public required ReviewTemplateDTO Template { get; set; }
+    
+    /// <summary>
+    /// The review assignment associated with the current user, if the
+    /// current user is an assigned reviewer for this paper.
+    ///
+    /// This is used to disclose which review belongs to the current
+    /// reviewer while preserving anonymity for all other users.
+    /// </summary>
+    [Parameter]
+    public Guid? CurrentUserReviewAssignmentId { get; set; }
 }

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewPageContainer.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewPageContainer.razor
@@ -126,12 +126,23 @@ else
 
         var myAssignments = await ReviewAssignmentService
             .GetReviewerPapersAsync(_currentUserId);
-        
-        _paper = await PaperQueryService
-            .GetPaperDetailsAsync(PaperId, _currentUserId);
 
         _assignment = myAssignments
             .FirstOrDefault(a => a.PaperId == PaperId);
+
+        // Only authors need paper lifecycle visibility checks.
+        // Reviewers already have assignment-based visibility.
+        if (_assignment is null && !_isPrivilegedUser)
+        {
+            _paper = await PaperQueryService
+                .GetPaperDetailsAsync(
+                    PaperId,
+                    _currentUserId);
+        }
+        else
+        {
+            _paper = null;
+        }
         
         _template = await ReviewTemplateService.GetActiveTemplateAsync();
 
@@ -150,7 +161,7 @@ else
 
         // Determine visibility
         var reviewerCanView =
-            _assignment?.ReviewSubmittedAtUtc != null;
+            _assignment?.ReviewSubmittedAtUtc is not null;
 
         var authorCanView =
             _paper is not null &&

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewPageContainer.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewPageContainer.razor
@@ -1,14 +1,17 @@
 @using Reviewer2.Services.CRUD.ReviewTemplates
+@using Reviewer2.Services.DTOs.PaperSubmission
 @using Reviewer2.Services.DTOs.ReviewAssignments
 @using Reviewer2.Services.DTOs.ReviewSubmission
 @using Reviewer2.Services.DTOs.ReviewTemplates
 @using Reviewer2.Services.Reviews
 @using Reviewer2.Services.ReviewAssignments
+@using Reviewer2.Services.Submissions.PaperSubmission
 
 @inject IReviewService ReviewService
 @inject IReviewAssignmentService ReviewAssignmentService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IReviewTemplateService ReviewTemplateService
+@inject IPaperQueryService PaperQueryService
 
 @if (_assignment is not null)
 {
@@ -56,6 +59,12 @@ else if (_canViewAllReviews && _template is not null)
         Reviews="_reviews"
         Template="_template" />
 }
+else if (_assignment is null && !_isPrivilegedUser)
+{
+    <div class="alert alert-info">
+        Reviews are not yet available for this paper.
+    </div>
+}
 else
 {
     <div class="alert alert-info">
@@ -72,6 +81,7 @@ else
 
     private Guid _currentUserId;
 
+    private PaperDetailsDTO? _paper;
     private ReviewerPaperDTO? _assignment;
     private ReviewDTO? _myReview;
     private List<ReviewDTO> _reviews = [];
@@ -116,6 +126,9 @@ else
 
         var myAssignments = await ReviewAssignmentService
             .GetReviewerPapersAsync(_currentUserId);
+        
+        _paper = await PaperQueryService
+            .GetPaperDetailsAsync(PaperId, _currentUserId);
 
         _assignment = myAssignments
             .FirstOrDefault(a => a.PaperId == PaperId);
@@ -135,10 +148,19 @@ else
                 _assignment.ReviewAssignmentId,
                 _currentUserId);
 
-        // Determine visibility (centralized)
+        // Determine visibility
+        var reviewerCanView =
+            _assignment?.ReviewSubmittedAtUtc != null;
+
+        var authorCanView =
+            _paper is not null &&
+            PaperVisibilityPolicy.CanAuthorViewReviews(
+                _paper.Status);
+
         _canViewAllReviews =
             _isPrivilegedUser ||
-            _assignment?.ReviewSubmittedAtUtc != null;
+            reviewerCanView ||
+            authorCanView;
 
         // Load reviews only if allowed
         _reviews = _canViewAllReviews

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewPageContainer.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewPageContainer.razor
@@ -57,7 +57,8 @@ else if (_canViewAllReviews && _template is not null)
 {
     <ReviewList
         Reviews="_reviews"
-        Template="_template" />
+        Template="_template" 
+        CurrentUserReviewAssignmentId="_assignment?.ReviewAssignmentId"/>
 }
 else if (_assignment is null && !_isPrivilegedUser)
 {

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewViewer.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperReviewing/ReviewViewer.razor
@@ -6,7 +6,9 @@
 
         <h6 class="card-subtitle mb-2">
             <span class="badge bg-secondary me-2">
-                Reviewer @Index
+                @(IsMyReview
+                    ? "Your Review"
+                    : $"Reviewer {Index}")
             </span>
 
             @if (Review.SubmittedAtUtc is not null)
@@ -94,9 +96,16 @@
 
     [Parameter]
     public int Index { get; set; }
+    
+    [Parameter]
+    public Guid? CurrentUserReviewAssignmentId { get; set; }
 
     private static string DisplayOrDash(int? value)
         => value?.ToString() ?? "-";
+    
+    private bool IsMyReview =>
+        CurrentUserReviewAssignmentId is { } assignmentId &&
+        Review.ReviewAssignmentId == assignmentId;
 
     private static string DisplayFieldValue(
         ReviewFieldType type,

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
@@ -19,11 +19,14 @@
 
         <div class="d-flex gap-2">
 
-            <button class="btn btn-primary"
-                    @onclick="GoToReviews">
-                <i class="bi bi-clipboard-check"></i>
-                View Reviews
-            </button>
+            @if (_paper is { Status: >= PaperStatus.UnderReview })
+            {
+                <button class="btn btn-primary"
+                        @onclick="GoToReviews">
+                    <i class="bi bi-clipboard-check"></i>
+                    View Reviews
+                </button>
+            }
 
             <button class="btn btn-outline-secondary"
                     @onclick="GoBack">

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionDetailsPage.razor
@@ -347,6 +347,27 @@ else
                 memoryStream,
                 _selectedUploadFile.Name,
                 _currentUserId.Value);
+            
+            // Complete workflow transitions for special file types
+            switch (_selectedUploadType)
+            {
+                case FileType.Revision:
+                    await PaperService.ResubmitAfterRevisionAsync(
+                        PaperId,
+                        _currentUserId.Value);
+                    break;
+
+                case FileType.CameraReady:
+                    await PaperService.SubmitCameraReadyAsync(
+                        PaperId,
+                        _currentUserId.Value);
+                    break;
+                case FileType.InitialSubmission:
+                case FileType.CopyrightForm:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
 
             _selectedUploadFile = null;
 

--- a/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionsPage.razor
+++ b/Reviewer2/Reviewer2.Blazor/Components/Pages/PaperSubmissions/SubmissionsPage.razor
@@ -221,6 +221,7 @@
             "Accepted" => "Accepted",
             "Rejected" => "Rejected",
             "Withdrawn" => "Withdrawn",
+            "CameraReadySubmitted" => "Camera Ready Submitted",
             _ => status
         };
     
@@ -234,6 +235,7 @@
             "Accepted" => "bg-success",
             "Rejected" => "bg-danger",
             "Withdrawn" => "bg-dark",
+            "CameraReadySubmitted" => "bg-success-subtle text-success-emphasis",
             _ => "bg-light text-dark"
         };
     

--- a/Reviewer2/Reviewer2.Data/Models/Paper.cs
+++ b/Reviewer2/Reviewer2.Data/Models/Paper.cs
@@ -216,7 +216,7 @@ public class Paper
     /// 
     /// This operation is used after the authors upload an updated version
     /// addressing the requested revisions. The paper may either undergo
-    /// another round of review or proceed directly to decision depending
+    /// another round of review or proceed directly to a decision depending
     /// on conference policy.
     /// </summary>
     /// <exception cref="InvalidOperationException">
@@ -227,6 +227,10 @@ public class Paper
     {
         if (Status != PaperStatus.RevisionRequired)
             throw new InvalidOperationException("Paper is not awaiting revisions.");
+        
+        if (Files.All(f => f.Type != FileType.Revision))
+            throw new InvalidOperationException(
+                "A revised submission file is required.");
 
         Status = PaperStatus.UnderReview;
     }

--- a/Reviewer2/Reviewer2.Data/Models/Paper.cs
+++ b/Reviewer2/Reviewer2.Data/Models/Paper.cs
@@ -161,7 +161,7 @@ public class Paper
     /// to <see cref="PaperStatus.ReviewsCompleted"/>.
     /// 
     /// This indicates that the required number of reviews has been received
-    /// and the paper is ready for final decision.
+    /// and the paper is ready for a final decision.
     /// </summary>
     /// <exception cref="InvalidOperationException">
     /// Thrown if the paper is not currently under review.

--- a/Reviewer2/Reviewer2.Data/Models/ReviewAssignment.cs
+++ b/Reviewer2/Reviewer2.Data/Models/ReviewAssignment.cs
@@ -68,7 +68,7 @@ public class ReviewAssignment
 public enum ReviewStatus
 {
     /// <summary>
-    /// The review has been assigned but the reviewer has not yet started.
+    /// The review has been assigned, but the reviewer has not yet started.
     /// </summary>
     Pending = 0,
 

--- a/Reviewer2/Reviewer2.Services/DTOs/PaperSubmission/PaperDetailsDTO.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/PaperSubmission/PaperDetailsDTO.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Reviewer2.Data.Models;
 
 namespace Reviewer2.Services.DTOs.PaperSubmission
 {
@@ -28,7 +29,7 @@ namespace Reviewer2.Services.DTOs.PaperSubmission
         /// <summary>
         /// Gets or sets the current workflow status of the paper (e.g., Draft, Submitted, Accepted).
         /// </summary>
-        public string Status { get; set; } = string.Empty;
+        public PaperStatus Status { get; set; }
 
         /// <summary>
         /// Gets or sets the UTC date and time when the paper was submitted.
@@ -56,12 +57,12 @@ namespace Reviewer2.Services.DTOs.PaperSubmission
         /// Gets or sets a list of authors for the paper.
         /// Each entry is formatted as "Name (Role)" for display purposes.
         /// </summary>
-        public List<string> Authors { get; set; } = new();
+        public List<string> Authors { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the list of files associated with the paper.
-        /// Includes file type, name, and optional URL for preview or download.
+        /// Includes a file type, name, and optional URL for preview or download.
         /// </summary>
-        public List<PaperFileSummaryDTO> Files { get; set; } = new();
+        public List<PaperFileSummaryDTO> Files { get; set; } = [];
     }
 }

--- a/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewAssignmentMapper.cs
@@ -30,7 +30,7 @@ namespace Reviewer2.Services.DTOs.ReviewAssignments
             {
                 PaperId = paper.Id,
                 Title = paper.Title,
-                PaperStatus = paper.Status.ToString(),
+                PaperStatus = paper.Status,
                 SubmittedAtUtc = paper.SubmittedAtUtc,
                 Authors = string.Join(", ", paper.Authors
                     .OrderBy(a => a.AuthorOrder)

--- a/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewerPaperDTO.cs
+++ b/Reviewer2/Reviewer2.Services/DTOs/ReviewAssignments/ReviewerPaperDTO.cs
@@ -36,7 +36,7 @@ public class ReviewerPaperDTO
     /// This reflects the overall conference decision process and is
     /// independent of the review assignment status.
     /// </summary>
-    public string PaperStatus { get; set; } = string.Empty;
+    public PaperStatus PaperStatus { get; set; }
 
     /// <summary>
     /// The date and time (UTC) when the paper was originally submitted.

--- a/Reviewer2/Reviewer2.Services/ReviewAssignments/ReviewAssignmentService.cs
+++ b/Reviewer2/Reviewer2.Services/ReviewAssignments/ReviewAssignmentService.cs
@@ -130,7 +130,6 @@ public class ReviewAssignmentService : IReviewAssignmentService
 
         paper.ReviewAssignments.Add(new ReviewAssignment
         {
-            Id = Guid.NewGuid(),
             PaperId = paperId,
             ReviewerId = reviewerId,
             Status = ReviewStatus.Pending
@@ -145,8 +144,16 @@ public class ReviewAssignmentService : IReviewAssignmentService
                 "Paper {PaperId} transitioned to UnderReview",
                 paperId);
         }
-
-        await context.SaveChangesAsync();
+        
+        try
+        {
+            await context.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Save failed");
+            throw;
+        }
         
         Log.Information(
             "Reviewer {ReviewerId} assigned to paper {PaperId}",
@@ -326,7 +333,6 @@ public class ReviewAssignmentService : IReviewAssignmentService
                 {
                     paper.ReviewAssignments.Add(new ReviewAssignment
                     {
-                        Id = Guid.NewGuid(),
                         PaperId = paper.Id,
                         ReviewerId = reviewer.ReviewerId,
                         Status = ReviewStatus.Pending

--- a/Reviewer2/Reviewer2.Services/ReviewAssignments/ReviewAssignmentService.cs
+++ b/Reviewer2/Reviewer2.Services/ReviewAssignments/ReviewAssignmentService.cs
@@ -92,11 +92,12 @@ public class ReviewAssignmentService : IReviewAssignmentService
     {
         await using var context = await _contextFactory.CreateDbContextAsync();
 
-        // Optional but recommended: verify paper exists
-        bool paperExists = await context.Papers
-            .AnyAsync(p => p.Id == paperId);
-
-        if (!paperExists)
+        // verify paper exists
+        var paper = await context.Papers
+            .Include(p => p.ReviewAssignments)
+            .FirstOrDefaultAsync(p => p.Id == paperId);
+        
+        if (paper is null)
             return AssignmentResult.NotFound;
 
         var reviewerIds = await GetReviewerIdsAsync();
@@ -110,7 +111,7 @@ public class ReviewAssignmentService : IReviewAssignmentService
             .FirstAsync();
         
         // Conflict check (author)
-        bool isAuthor = await context.Authors.AnyAsync(a =>
+        var isAuthor = await context.Authors.AnyAsync(a =>
             a.PaperId == paperId &&
             (
                 (a.UserId != null && a.UserId == reviewer.Id) ||
@@ -121,23 +122,36 @@ public class ReviewAssignmentService : IReviewAssignmentService
             return AssignmentResult.ReviewerIsAuthor;
 
         // Duplicate check
-        bool exists = await context.ReviewAssignments
+        var exists = await context.ReviewAssignments
             .AnyAsync(a => a.PaperId == paperId && a.ReviewerId == reviewerId);
 
         if (exists)
             return AssignmentResult.AlreadyAssigned;
 
-        var assignment = new ReviewAssignment
+        paper.ReviewAssignments.Add(new ReviewAssignment
         {
             Id = Guid.NewGuid(),
             PaperId = paperId,
             ReviewerId = reviewerId,
             Status = ReviewStatus.Pending
-        };
+        });
 
-        context.ReviewAssignments.Add(assignment);
+        // Domain transition
+        if (paper.Status == PaperStatus.Submitted)
+        {
+            paper.MoveToUnderReview();
+
+            Log.Information(
+                "Paper {PaperId} transitioned to UnderReview",
+                paperId);
+        }
 
         await context.SaveChangesAsync();
+        
+        Log.Information(
+            "Reviewer {ReviewerId} assigned to paper {PaperId}",
+            reviewerId,
+            paperId);
 
         return AssignmentResult.Success;
     }
@@ -167,12 +181,12 @@ public class ReviewAssignmentService : IReviewAssignmentService
         await using var context = await _contextFactory.CreateDbContextAsync();
 
         // Ensure paper exists
-        bool paperExists = await context.Papers
+        var paperExists = await context.Papers
             .AsNoTracking()
             .AnyAsync(p => p.Id == paperId);
 
         if (!paperExists)
-            return new List<ReviewerCandidateDTO>();
+            return [];
 
         // Get author user IDs (for conflict detection)
         var authorUserIds = await context.Authors
@@ -256,9 +270,9 @@ public class ReviewAssignmentService : IReviewAssignmentService
         await using var context = await _contextFactory.CreateDbContextAsync();
 
         var papers = await context.Papers
+            .Include(p => p.ReviewAssignments)
             .Where(p => p.Status == PaperStatus.Submitted ||
                         p.Status == PaperStatus.UnderReview)
-            .Select(p => new { p.Id, p.Title })
             .ToListAsync();
 
         // Global assignment counts (mutable for fairness)
@@ -284,7 +298,7 @@ public class ReviewAssignmentService : IReviewAssignmentService
                 {
                     PaperId = paper.Id,
                     Title = paper.Title,
-                    SuggestedReviewers = new(),
+                    SuggestedReviewers = [],
                     IsIncomplete = false
                 });
 
@@ -306,23 +320,32 @@ public class ReviewAssignmentService : IReviewAssignmentService
                 assignmentCounts[reviewer.ReviewerId] =
                     assignmentCounts.GetValueOrDefault(reviewer.ReviewerId) + 1;
 
-                if (!existingReviewerIds.Contains(reviewer.ReviewerId))
+                if (existingReviewerIds.Contains(reviewer.ReviewerId)) continue;
+                
+                if (persist)
                 {
-                    if (persist)
+                    paper.ReviewAssignments.Add(new ReviewAssignment
                     {
-                        context.ReviewAssignments.Add(new ReviewAssignment
-                        {
-                            Id = Guid.NewGuid(),
-                            PaperId = paper.Id,
-                            ReviewerId = reviewer.ReviewerId,
-                            Status = ReviewStatus.Pending
-                        });
+                        Id = Guid.NewGuid(),
+                        PaperId = paper.Id,
+                        ReviewerId = reviewer.ReviewerId,
+                        Status = ReviewStatus.Pending
+                    });
+                    
+                    // Domain transition
+                    if (paper.Status == PaperStatus.Submitted)
+                    {
+                        paper.MoveToUnderReview();
 
-                        created++;
+                        Log.Information(
+                            "Paper {PaperId} transitioned to UnderReview during auto-assignment",
+                            paper.Id);
                     }
 
-                    existingReviewerIds.Add(reviewer.ReviewerId);
+                    created++;
                 }
+
+                existingReviewerIds.Add(reviewer.ReviewerId);
             }
 
             results.Add(new AutoAssignmentPreviewDTO

--- a/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/IPaperSubmissionService.cs
+++ b/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/IPaperSubmissionService.cs
@@ -116,4 +116,47 @@ public interface IPaperSubmissionService
     /// before submission is allowed.
     /// </remarks>
     Task SubmitAsync(Guid paperId, Guid userId);
+    
+    /// <summary>
+    /// Resubmits a paper after the required revision file
+    /// has been uploaded.
+    /// </summary>
+    /// <param name="paperId">
+    /// The identifier of the paper being resubmitted.
+    /// </param>
+    /// <param name="userId">
+    /// The identifier of the user performing the resubmission.
+    /// </param>
+    /// <returns>
+    /// A task representing the asynchronous operation.
+    /// </returns>
+    /// <remarks>
+    /// The paper must currently be in the RevisionRequired state
+    /// and have an uploaded revision file.
+    /// </remarks>
+    Task ResubmitAfterRevisionAsync(
+        Guid paperId,
+        Guid userId);
+
+
+    /// <summary>
+    /// Submits the camera-ready version of an accepted paper
+    /// after the required file has been uploaded.
+    /// </summary>
+    /// <param name="paperId">
+    /// The identifier of the accepted paper.
+    /// </param>
+    /// <param name="userId">
+    /// The identifier of the user performing the submission.
+    /// </param>
+    /// <returns>
+    /// A task representing the asynchronous operation.
+    /// </returns>
+    /// <remarks>
+    /// The paper must currently be accepted
+    /// and have an uploaded camera-ready file.
+    /// </remarks>
+    Task SubmitCameraReadyAsync(
+        Guid paperId,
+        Guid userId);
 }

--- a/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperQueryService.cs
+++ b/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperQueryService.cs
@@ -148,7 +148,7 @@ public class PaperQueryService : IPaperQueryService
             PaperId = paper.Id,
             Title = paper.Title,
             Abstract = paper.Abstract,
-            Status = paper.Status.ToString(),
+            Status = paper.Status,
             SubmittedAtUtc = paper.SubmittedAtUtc,
             DecisionMadeAtUtc = paper.LastDecisionAtUtc,
             SubmitterUserId = paper.SubmitterUserId,

--- a/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperSubmissionService.cs
+++ b/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperSubmissionService.cs
@@ -255,4 +255,138 @@ public class PaperSubmissionService : IPaperSubmissionService
             throw new InvalidOperationException("An unexpected error occurred while submitting the paper. See logs for details.", ex);
         }
     }
+    
+    /// <inheritdoc/>
+    public async Task ResubmitAfterRevisionAsync(Guid paperId, Guid userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        try
+        {
+            var paper = await context.Papers
+                .Include(p => p.Files)
+                .FirstOrDefaultAsync(p => p.Id == paperId);
+
+            if (paper is null)
+            {
+                Log.Warning(
+                    "ResubmitAfterRevisionAsync failed: paper {PaperId} not found",
+                    paperId);
+
+                throw new InvalidOperationException("Paper not found.");
+            }
+
+            if (paper.SubmitterUserId != userId)
+            {
+                Log.Warning(
+                    "Unauthorized revision resubmission attempt for paper {PaperId} by user {UserId}",
+                    paperId,
+                    userId);
+
+                throw new UnauthorizedAccessException(
+                    "You are not authorized to modify this paper.");
+            }
+
+            try
+            {
+                paper.ResubmitAfterRevision();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Log.Warning(
+                    ex,
+                    "Paper {PaperId} failed revision resubmission due to business rule violation",
+                    paperId);
+
+                throw;
+            }
+
+            await context.SaveChangesAsync();
+
+            Log.Information(
+                "Paper {PaperId} successfully resubmitted after revision by user {UserId}",
+                paperId,
+                userId);
+        }
+        catch (Exception ex) when (
+            ex is not (InvalidOperationException or UnauthorizedAccessException))
+        {
+            Log.Error(
+                ex,
+                "Unexpected error during ResubmitAfterRevisionAsync for paper {PaperId} by user {UserId}",
+                paperId,
+                userId);
+
+            throw new InvalidOperationException(
+                "An unexpected error occurred while resubmitting the paper. See logs for details.",
+                ex);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task SubmitCameraReadyAsync(Guid paperId, Guid userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        try
+        {
+            var paper = await context.Papers
+                .Include(p => p.Files)
+                .FirstOrDefaultAsync(p => p.Id == paperId);
+
+            if (paper is null)
+            {
+                Log.Warning(
+                    "SubmitCameraReadyAsync failed: paper {PaperId} not found",
+                    paperId);
+
+                throw new InvalidOperationException("Paper not found.");
+            }
+
+            if (paper.SubmitterUserId != userId)
+            {
+                Log.Warning(
+                    "Unauthorized camera-ready submission attempt for paper {PaperId} by user {UserId}",
+                    paperId,
+                    userId);
+
+                throw new UnauthorizedAccessException(
+                    "You are not authorized to modify this paper.");
+            }
+
+            try
+            {
+                paper.SubmitCameraReady();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Log.Warning(
+                    ex,
+                    "Paper {PaperId} failed camera-ready submission due to business rule violation",
+                    paperId);
+
+                throw;
+            }
+
+            await context.SaveChangesAsync();
+
+            Log.Information(
+                "Paper {PaperId} successfully submitted camera-ready version by user {UserId}",
+                paperId,
+                userId);
+        }
+        catch (Exception ex) when (
+            ex is not (InvalidOperationException or UnauthorizedAccessException))
+        {
+            Log.Error(
+                ex,
+                "Unexpected error during SubmitCameraReadyAsync for paper {PaperId} by user {UserId}",
+                paperId,
+                userId);
+
+            throw new InvalidOperationException(
+                "An unexpected error occurred while submitting the camera-ready version. See logs for details.",
+                ex);
+        }
+    }
 }

--- a/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperVisibilityPolicy.cs
+++ b/Reviewer2/Reviewer2.Services/Submissions/PaperSubmission/PaperVisibilityPolicy.cs
@@ -1,0 +1,48 @@
+using Reviewer2.Data.Models;
+
+namespace Reviewer2.Services.Submissions.PaperSubmission;
+
+/// <summary>
+/// Provides centralized visibility rules for determining when
+/// paper-related information may be shown to users based on
+/// the current lifecycle state of a paper.
+/// 
+/// This policy is intended to keep paper access rules
+/// consistent across UI components, API endpoints, and
+/// service-layer authorization checks.
+/// </summary>
+public static class PaperVisibilityPolicy
+{
+    /// <summary>
+    /// Determines whether an author may view the anonymous
+    /// reviews associated with their paper based on the
+    /// paper's current status.
+    /// 
+    /// Authors may view reviews only after the review
+    /// process has reached a stage where reviewer feedback
+    /// is intended to be disclosed, such as when revisions
+    /// are requested or a final decision has been made.
+    /// </summary>
+    /// <param name="status">
+    /// The current workflow status of the paper.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the author is permitted
+    /// to view reviews for the specified status;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool CanAuthorViewReviews(PaperStatus status)
+    {
+        return status switch
+        {
+            PaperStatus.RevisionRequired => true,
+            PaperStatus.Accepted => true,
+            PaperStatus.Rejected => true,
+            PaperStatus.CameraReadySubmitted => true,
+            PaperStatus.Scheduled => true,
+            PaperStatus.Presented => true,
+
+            _ => false
+        };
+    }
+}


### PR DESCRIPTION
## Fixes/Improvements
* A paper's status will now update in these additional scenarios where it did not before...
   * A review assignment is made (status will go from Submitted to Under Review)
   * A revised paper is submitted (status will go from Revision Required to Under Review)
   * A camera ready copy is submitted (status will go from Accepted to Camera Ready Submitted)
* Authors can now see reviews for their paper once it has been accepted or is in any later status (see the `PaperVisibilityPolicy` for more details).
* Personal reviews can be identified on the review page with the label "_My Review_."

## Known Issues
For a paper to move from the _Under Review_ to _Reviews Completed_ status, three reviews must be completed. This is currently hard-coded and not persisted.